### PR TITLE
Gbat snps

### DIFF
--- a/docs/build/gcta_build_steps_linux.sh
+++ b/docs/build/gcta_build_steps_linux.sh
@@ -35,6 +35,8 @@ cd spectra-1.0.0/
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=$rootdir/spectra_pkg ..
+make
+make install
 
 cd $rootdir/gcta_dep
 tar -zxf gsl-2.7.tar.gz

--- a/main/gbat.cpp
+++ b/main/gbat.cpp
@@ -100,7 +100,7 @@ void gcta::gbat_calcu_ld(MatrixXf &X, eigenVector &sumsq_x, int snp1_indx, int s
     }
 }
 
-void gcta::gbat(string sAssoc_file, string gAnno_file, int wind, int simu_num)
+void gcta::gbat(string sAssoc_file, string gAnno_file, int wind, int simu_num, int max_snps)
 {
     int i = 0, j = 0;
 
@@ -200,9 +200,9 @@ void gcta::gbat(string sAssoc_file, string gAnno_file, int wind, int simu_num)
         bool skip = false;
         if (iter1 == snp_name_map.end() || iter2 == snp_name_map.end() || iter1->second >= iter2->second) skip = true;
         snp_num_in_gene[i] = iter2->second - iter1->second + 1;
-        if(!skip && snp_num_in_gene[i] > 10000){
-            LOGGER<<"Warning: Too many SNPs in the gene region ["<<gene_name[i]<<"]. Maximum limit is 10000. This gene is ignored in the analysis."<<endl;
-            skip = true;  
+        if(!skip && snp_num_in_gene[i] > max_snps){
+            LOGGER<<"Warning: Too many SNPs ("<<snp_num_in_gene[i]<<") in the gene region ["<<gene_name[i]<<"]. Maximum limit is ["<<max_snps<<"]. This gene is ignored in the analysis."<<endl;
+            skip = true; 
         } 
         if(skip){
             gene_pval[i] = 2.0;

--- a/main/gcta.h
+++ b/main/gcta.h
@@ -430,7 +430,7 @@ private:
 	void gbat_read_snpAssoc(string snpAssoc_file, vector<string>& snp_name, vector<int>& snp_chr, vector<int>& snp_bp, vector<double>& snp_pval);
 	void gbat_read_geneAnno(string gAnno_file, vector<string>& gene_name, vector<int>& gene_chr, vector<int>& gene_bp1, vector<int>& gene_bp2);
 	void gbat_calcu_ld(MatrixXf & X, eigenVector & sumsq_x, int snp1_indx, int snp2_indx, MatrixXf & C);
-	void gbat(string sAssoc_file, string gAnno_file, int wind, int simu_num);
+	void gbat(string sAssoc_file, string gAnno_file, int wind, int simu_num, int max_snps);
 	double gbat_simu_p(int & seed, int size, eigenMatrix & L, int simu_num, double chisq_o);
 
 

--- a/main/option.cpp
+++ b/main/option.cpp
@@ -154,6 +154,9 @@ void option(int option_num, char* option_str[])
     string mbat_sAssoc_file = "", mbat_gAnno_file = "", mbat_snpset_file = "";
     int mbat_wind = 50000;
     bool mbat_print_all_p = false;
+
+    // Max number of SNPs for gene-based association test
+    int max_snps = 10000;
    
     // gene expression data
     string efile="", eR_file = "", ecojo_ma_file="";
@@ -1008,6 +1011,9 @@ void option(int option_num, char* option_str[])
             LOGGER << "--mBAT-wind " << mbat_wind << endl;
             if (mbat_wind < 0 || mbat_wind > 1000) LOGGER.e(0, "\n invalid value for --mBAT-wind. Valid range: 0 ~ 1000\n");
             mbat_wind *= 1000;
+        } else if (strcmp(argv[i], "--max_snps") == 0) {
+            max_snps = atoi(argv[++i]);
+            LOGGER << "--max_snps " << max_snps << endl;
         } 
         else if (strcmp(argv[i], "--efile") == 0) {
             efile = argv[++i];


### PR DESCRIPTION
This pull request adds the option `--max-snps` which can be used to change the maximum number of SNPs allowed in a gene-based association test from the default 10,000.

It also adds additional commands to build the Spectra dependency in build steps example.